### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.6.4",
         "guzzlehttp/guzzle": "^6.3",
-        "illuminate/support": "^5.4"
+        "illuminate/support": "5.4.* || 5.5.*"
     },
     "require-dev": {
         "graham-campbell/testbench": "^3.4",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.